### PR TITLE
fix issue 436

### DIFF
--- a/01_conda.ipynb
+++ b/01_conda.ipynb
@@ -116,13 +116,12 @@
     "#export\n",
     "def conda_output_path(name,ver):\n",
     "    \"Output path for conda build\"\n",
-    "    pre = run('conda info --root').strip()\n",
+    "    pre = run('conda info --root', same_in_win=True).strip()\n",
     "    s = f\"{as_posix(pre)}/conda-bld/*/{name}-{ver}-py\"\n",
-    "    res = first(glob.glob(f\"{s}_0.tar.bz2\"))\n",
+    "    res = glob.glob(f\"{s}_0.tar.bz2\")\n",
     "    if not res:\n",
-    "        pyver = strcat(sys.version_info[:2])\n",
-    "        res = first(glob.glob(f\"{s}{pyver}_0.tar.bz2\"))\n",
-    "    return as_posix(res)"
+    "        res = glob.glob(f\"{s}*_0.tar.bz2\")\n",
+    "    if res: return [as_posix(i) for i in res]"
    ]
   },
   {
@@ -143,7 +142,7 @@
     "    d1 = {\n",
     "        'package': {'name': name, 'version': ver},\n",
     "        'source': {'url':rel['url'], 'sha256':rel['digests']['sha256']}\n",
-    "    }\n",
+    "    }   \n",
     "    d2 = {\n",
     "        'build': {'number': '0', 'noarch': 'python',\n",
     "                  'script': '{{ PYTHON }} -m pip install . -vv'},\n",
@@ -178,6 +177,25 @@
    "outputs": [],
    "source": [
     "#export\n",
+    "def _write_buildconfig_yaml(path, name):\n",
+    "    path = Path(path)\n",
+    "    p = path/name\n",
+    "    p.mkdir(exist_ok=True, parents=True)\n",
+    "    yaml.SafeDumper.ignore_aliases = lambda *args : True\n",
+    "    with (p/'conda_build_config.yaml').open('w') as f:\n",
+    "        d1 = {\n",
+    "            'python': [3.6, 3.7, 3.8]\n",
+    "        }\n",
+    "        yaml.safe_dump(d1, f)  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#export\n",
     "def write_pip_conda_meta(name, path='conda'):\n",
     "    \"Writes a `meta.yaml` file for `name` to the `conda` directory of the current directory\"\n",
     "    _write_yaml(path, name, *_pip_conda_meta(name, path))"
@@ -190,7 +208,7 @@
    "outputs": [],
    "source": [
     "#export\n",
-    "def _get_conda_meta():\n",
+    "def _get_conda_meta(pure_python=True):\n",
     "    cfg,cfg_path = find_config()\n",
     "    name,ver = cfg.get('lib_name'),cfg.get('version')\n",
     "    url = cfg.get('doc_host') or cfg.get('git_url')\n",
@@ -208,9 +226,14 @@
     "        'source': {'url':rel['url'], 'sha256':rel['digests']['sha256']}\n",
     "    }\n",
     "\n",
+    "    if not pure_python and sys.platform == 'win32':\n",
+    "        build_section = {'number': '0', 'win-64': 'python',\n",
+    "                    'script': '{{ PYTHON }} setup.py install --single-version-externally-managed --record=record.txt'}\n",
+    "    else:\n",
+    "        build_section = {'number': '0', 'noarch': 'python',\n",
+    "                  'script': '{{ PYTHON }} -m pip install . -vv'}\n",
     "    d2 = {\n",
-    "        'build': {'number': '0', 'noarch': 'python',\n",
-    "                  'script': '{{ PYTHON }} -m pip install . -vv'},\n",
+    "        'build': build_section,\n",
     "        'requirements': {'host':reqs, 'run':reqs},\n",
     "        'test': {'imports': [cfg.get('lib_path')]},\n",
     "        'about': {\n",
@@ -231,9 +254,12 @@
    "outputs": [],
    "source": [
     "#export\n",
-    "def write_conda_meta(path='conda'):\n",
+    "def write_conda_meta(path='conda', pure_python=True):\n",
     "    \"Writes a `meta.yaml` file to the `conda` directory of the current directory\"\n",
-    "    _write_yaml(path, *_get_conda_meta())"
+    "    _write_yaml(path, *_get_conda_meta(pure_python))\n",
+    "    if not pure_python and sys.platform == 'win32':\n",
+    "        cfg, _ = find_config()\n",
+    "        _write_buildconfig_yaml(path, cfg.get('lib_name'))"
    ]
   },
   {
@@ -252,12 +278,15 @@
    "outputs": [],
    "source": [
     "#export\n",
-    "def anaconda_upload(name, version, user=None, token=None, env_token=None):\n",
+    "def anaconda_upload(name, user=None, token=None, env_token=None):\n",
     "    \"Update `name` `version` to anaconda\"\n",
     "    user = f'-u {user} ' if user else ''\n",
     "    if env_token: token = os.getenv(env_token)\n",
     "    token = f'-t {token} ' if token else ''\n",
-    "    return run(f'anaconda {token} upload {user} {conda_output_path(name,version)} --skip-existing', stderr=True)"
+    "    locations = conda_output_path(name,version)\n",
+    "    for loc in locations:\n",
+    "        cmd_str = f'anaconda {token} upload {user} {loc} --skip-existing'\n",
+    "        run(cmd_str, same_in_win=True, stderr=True)"
    ]
   },
   {
@@ -273,21 +302,24 @@
     "                              build_args:Param(\"Additional args (as str) to send to `conda build`\", str)='',\n",
     "                              skip_upload:Param(\"Skip `anaconda upload` step\", store_true)=False,\n",
     "                              mambabuild:Param(\"Use `mambabuild` (requires `boa`)\", store_true)=False,\n",
-    "                              upload_user:Param(\"Optional user to upload package to\")=None):\n",
+    "                              upload_user:Param(\"Optional user to upload package to\")=None,\n",
+    "                              pure_python:Param(\"pure python package\", bool_arg)=True):\n",
     "    \"Create a `meta.yaml` file ready to be built into a package, and optionally build and upload it\"\n",
-    "    write_conda_meta(path)\n",
+    "    write_conda_meta(path, pure_python)\n",
     "    cfg,cfg_path = find_config()\n",
     "    out = f\"Done. Next steps:\\n```\\`cd {path}\\n\"\"\"\n",
     "    name,lib_path = cfg.get('lib_name'),cfg.get('lib_path')\n",
-    "    loc = conda_output_path(lib_path, cfg.get('version'))\n",
-    "    out_upl = f\"anaconda upload {loc}\"\n",
+    "    locations = conda_output_path(lib_path, cfg.get('version'))\n",
+    "    out_upl = \"\"\n",
+    "    for loc in locations:\n",
+    "        out_upl += f\"anaconda upload {loc}\\n\" \n",
     "    build = 'mambabuild' if mambabuild else 'build'\n",
-    "    if not do_build: return print(f\"{out}conda {build} .\\n{out_upl}\\n```\")\n",
+    "    if not do_build: return print(f\"{out}conda {build} .\\n{out_upl}```\")\n",
     "\n",
     "    os.chdir(path)\n",
-    "    res = run(f\"conda {build} --no-anaconda-upload {build_args} {name}\")\n",
+    "    res = run(f\"conda {build} --no-anaconda-upload {build_args} {name}\", same_in_win=True)\n",
     "    if 'anaconda upload' not in res: return print(f\"{res}\\n\\Failed. Check auto-upload not set in .condarc. Try `--do_build False`.\")\n",
-    "    return anaconda_upload(lib_path, cfg.get('version'))"
+    "    anaconda_upload(lib_path)"
    ]
   },
   {
@@ -305,6 +337,10 @@
     "cd conda\n",
     "conda build --no-anaconda-upload --output-folder build {name}\n",
     "anaconda upload build/noarch/{name}-{ver}-*.tar.bz2\n",
+    "```\n",
+    "If the package isn't a pure python package on Windows, for example nbdev, the last command is\n",
+    "```\n",
+    "anaconda upload build/win-64/{name}-{ver}-*.tar.bz2\n",
     "```\n",
     "\n",
     "Add `--debug` to the `conda build command` to debug any problems that occur. Note that the build step takes a few minutes. Add `-u {org_name}` to the `anaconda upload` command if you wish to upload to an organization, or pass `upload_user` to `fastrelease_conda_package`.\n",
@@ -326,7 +362,7 @@
     "                  force:Param('Always return github tag', store_true)=False):\n",
     "    \"Prints GitHub tag only if a newer release exists on Pypi compared to an Anaconda Repo.\"\n",
     "    if not apkg: apkg=nm\n",
-    "    condavs = L(loads(run(f'mamba repoquery search {apkg} -c {channel} --json'))['result']['pkgs'])\n",
+    "    condavs = L(loads(run(f'mamba repoquery search {apkg} -c {channel} --json', same_in_win=True))['result']['pkgs'])\n",
     "    condatag = condavs.attrgot('version').map(parse)\n",
     "    pypitag = latest_pypi(nm)\n",
     "    if force or not condatag or pypitag > max(condatag): return f'{pypitag}'"


### PR DESCRIPTION
Fix #436
depends on PR #305

nbdev isn't a pure python package because it generates many cli command.
So, in meta.yml, we shouldn't use noarch:python but win-64:python.


It changes fastrelease a lot, If there's better method please let me know.