### PR TITLE
fix main/master naming

### DIFF
--- a/00_core.ipynb
+++ b/00_core.ipynb
@@ -147,7 +147,7 @@
     "        \"Tag and create a release in GitHub for the current version\"\n",
     "        ver = self.cfg.version\n",
     "        notes = self.latest_notes()\n",
-    "        self.gh.create_release(ver, body=notes)\n",
+    "        self.gh.create_release(ver, branch=self.cfg.branch, body=notes)\n",
     "        return ver\n",
     "\n",
     "    def latest_notes(self):\n",
@@ -394,9 +394,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/fastrelease/core.py
+++ b/fastrelease/core.py
@@ -80,7 +80,7 @@ class FastRelease:
         "Tag and create a release in GitHub for the current version"
         ver = self.cfg.version
         notes = self.latest_notes()
-        self.gh.create_release(ver, body=notes)
+        self.gh.create_release(ver, branch=self.cfg.branch, body=notes)
         return ver
 
     def latest_notes(self):


### PR DESCRIPTION
Adds support for repos where `master` is called `main`
